### PR TITLE
chore: add support down to v0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: c++
 sudo: false
 env:
+  - NODE_VERSION="0.11"
+  - NODE_VERSION="0.12"
+  - NODE_VERSION="1"
+  - NODE_VERSION="2"
+  - NODE_VERSION="3"
   - NODE_VERSION="4"
   - NODE_VERSION="5"
   - NODE_VERSION="6"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ shell.open('file.txt'); // the plugin is now available!
  - OS X
  - Windows
 
-This is only supported for Node v4+
+This is supported for Node v0.11+
 
 ## Writing plugins
 

--- a/index.js
+++ b/index.js
@@ -3,14 +3,22 @@ var plugin = require('shelljs/plugin');
 
 // Require whatever modules you need for your project
 var opener = require('opener');
-var pathExists = require('path-exists');
+var fs = require('fs');
+var pathExistsSync = function (filePath) {
+  try {
+    fs.accessSync(filePath);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
 
 // Implement your command in a function, which accepts `options` as the
 // first parameter, and other arguments after that
 function open(options, fileName) {
   var URL_REGEX = /^https?:\/\/.*/;
 
-  if (!pathExists.sync(fileName) && !fileName.match(URL_REGEX)) {
+  if (!pathExistsSync(fileName) && !fileName.match(URL_REGEX)) {
     plugin.error('Unable to locate file: ' + fileName);
   }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "posttest": "npm run lint",
     "test": "mocha",
-    "lint": "eslint .",
+    "lint": "node scripts/eslint-wrapper.js",
     "changelog": "shelljs-changelog",
     "release:major": "shelljs-release major",
     "release:minor": "shelljs-release minor",
@@ -40,7 +40,6 @@
     "shelljs": "^0.7.3"
   },
   "dependencies": {
-    "opener": "^1.4.1",
-    "path-exists": "^3.0.0"
+    "opener": "^1.4.1"
   }
 }

--- a/scripts/eslint-wrapper.js
+++ b/scripts/eslint-wrapper.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+var exec = require('child_process').exec;
+
+// var version = process.version;
+var version = process.version.substr(1).split('.');
+if (parseInt(version[0], 10) >= 4) {
+  exec('eslint .', { stdio: 'inherit' }, function (code) {
+    process.exit(code);
+  });
+} else {
+  console.log('Linting is only supported on node v4+');
+  process.exit(0);
+}


### PR DESCRIPTION
This only performs linting for v4+, however, since that's the limit for eslint.
This should be fine, since we really only need to run linting once per pull
request anyway.