### PR TITLE
chore: bump shelljs dep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: c++
 sudo: false
 env:
-  - NODE_VERSION="0.11"
-  - NODE_VERSION="0.12"
-  - NODE_VERSION="1"
-  - NODE_VERSION="2"
-  - NODE_VERSION="3"
   - NODE_VERSION="4"
   - NODE_VERSION="5"
   - NODE_VERSION="6"
   - NODE_VERSION="7"
   - NODE_VERSION="8"
+  - NODE_VERSION="9"
 
 # keep this blank to make sure there are no before_install steps
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - nodejs_version: '9'
     - nodejs_version: '8'
     - nodejs_version: '7'
     - nodejs_version: '6'

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "eslint-config-airbnb-base": "^4.0.2",
     "eslint-plugin-import": "^1.11.1",
     "mocha": "^2.5.3",
-    "shelljs": "^0.7.3",
+    "shelljs": "^0.8.1",
     "shelljs-changelog": "^0.2.2",
     "shelljs-release": "^0.2.0",
     "should": "^10.0.0"
   },
   "peerDependencies": {
-    "shelljs": "^0.7.3"
+    "shelljs": "^0.8.1"
   },
   "dependencies": {
     "opener": "^1.4.1"

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
   },
   "dependencies": {
     "opener": "^1.4.1"
+  },
+  "engines": {
+    "node": ">=4"
   }
 }


### PR DESCRIPTION
Also, this drops support for node < 4 (because shelljs doesn't support it
anymore) and updates CI to go up to node 9.