### PR TITLE
chore: fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,17 +27,17 @@
     "index.js"
   ],
   "devDependencies": {
-    "eslint": "^5.16.0",
+    "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
-    "mocha": "^6.1.4",
-    "shelljs": "^0.8.1",
-    "shelljs-changelog": "^0.2.2",
+    "mocha": "^5.2.0",
+    "shelljs": "^0.8.5",
+    "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.2.0",
     "should": "^13.2.3"
   },
   "peerDependencies": {
-    "shelljs": "^0.8.1"
+    "shelljs": "^0.8.5"
   },
   "dependencies": {
     "opener": "^1.4.1"


### PR DESCRIPTION
This downgrades mocha and eslint for node v4. This upgrades shelljs and
related dependencies, which includes shelljs/shelljs#1058.