### PR TITLE
chore: update shelljs and drop old node support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 6
-          - 8
-          - 10
-          - 12
-          - 14
-          - 16
           - 18
+          - 20
+          - 22
         os:
           - ubuntu-latest
           - macos-latest
@@ -27,4 +23,4 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npm run test
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -31,18 +31,18 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",
     "mocha": "^5.2.0",
-    "shelljs": "^0.8.5",
+    "shelljs": "^0.9.1",
     "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.5.1",
     "should": "^13.2.3"
   },
   "peerDependencies": {
-    "shelljs": "^0.8.5"
+    "shelljs": "^0.9.1"
   },
   "dependencies": {
     "opener": "^1.4.1"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=18"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -124,7 +124,7 @@ describe('plugin-open', function () {
      * Plugins can easily take advantage of ShellJS's built-in glob expansion.
      * This is indicated by the globStart option
      */
-    var ret = shell.open('te?t/*st.js');
+    var ret = shell.open('te*/t?st.js');
     ret.code.should.equal(0);
     ret.stdout.should.equal('');
     assert.ok(!ret.stderr);


### PR DESCRIPTION
No change to logic. This updates the ShellJS peer dependency to the latest release. This also drops support for all node versions prior to v18 to match ShellJS's version range, and adds in node v20 and v22.

This modifies one unit test to work around a ShellJS bug (shelljs/shelljs#1197).

Test: npm test